### PR TITLE
Implement CG solver without preconditioner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,8 @@ DEAL_II_SETUP_TARGET(data_locality)
 
 ADD_SUBDIRECTORY(cmake)
 
+ADD_SUBDIRECTORY(benchmark_basic)
+ADD_SUBDIRECTORY(benchmark_merged)
 ADD_SUBDIRECTORY(benchmark_precond)
 ADD_SUBDIRECTORY(benchmark_precond_merged)
 ADD_SUBDIRECTORY(benchmark_s_step)
-

--- a/benchmark_basic/CMakeLists.txt
+++ b/benchmark_basic/CMakeLists.txt
@@ -1,0 +1,1 @@
+PICKUP_BENCHMARK(bench.cc)

--- a/benchmark_basic/bench.cc
+++ b/benchmark_basic/bench.cc
@@ -1,20 +1,19 @@
 
 #include "../common_code/benchmark.h"
-#include "../common_code/solver_cg_optimized.h"
 
 template <typename Operator, typename Preconditioner>
 unsigned int
 run_cg_solver(const Operator &                                  laplace_operator,
               LinearAlgebra::distributed::Vector<double> &      x,
               const LinearAlgebra::distributed::Vector<double> &b,
-              const Preconditioner &                            preconditioner)
+              const Preconditioner &)
 {
-  ReductionControl                                              solver_control(100, 1e-15, 1e-8);
-  SolverCGFullMerge<LinearAlgebra::distributed::Vector<double>> solver(solver_control);
+  ReductionControl                                     solver_control(100, 1e-15, 1e-8);
+  SolverCG<LinearAlgebra::distributed::Vector<double>> solver(solver_control);
 
   try
     {
-      solver.solve(laplace_operator, x, b, preconditioner);
+      solver.solve(laplace_operator, x, b, PreconditionIdentity());
       return solver_control.last_step();
     }
   catch (SolverControl::NoConvergence &e)

--- a/benchmark_merged/CMakeLists.txt
+++ b/benchmark_merged/CMakeLists.txt
@@ -1,0 +1,1 @@
+PICKUP_BENCHMARK(bench.cc)

--- a/benchmark_merged/bench.cc
+++ b/benchmark_merged/bench.cc
@@ -7,14 +7,14 @@ unsigned int
 run_cg_solver(const Operator &                                  laplace_operator,
               LinearAlgebra::distributed::Vector<double> &      x,
               const LinearAlgebra::distributed::Vector<double> &b,
-              const Preconditioner &                            preconditioner)
+              const Preconditioner &)
 {
   ReductionControl                                              solver_control(100, 1e-15, 1e-8);
   SolverCGFullMerge<LinearAlgebra::distributed::Vector<double>> solver(solver_control);
 
   try
     {
-      solver.solve(laplace_operator, x, b, preconditioner);
+      solver.solve(laplace_operator, x, b, PreconditionIdentity());
       return solver_control.last_step();
     }
   catch (SolverControl::NoConvergence &e)

--- a/common_code/benchmark.h
+++ b/common_code/benchmark.h
@@ -28,7 +28,6 @@
 #include "diagonal_matrix_blocked.h"
 #include "poisson_operator.h"
 #include "renumber_dofs_for_mf.h"
-#include "solver_cg_optimized.h"
 
 using namespace dealii;
 

--- a/common_code/poisson_operator.h
+++ b/common_code/poisson_operator.h
@@ -339,17 +339,6 @@ namespace Poisson
         dst.local_element(i) += src.local_element(i);
     }
 
-    void
-    vmult_with_merged_sums(
-      VectorType &                                                       dst,
-      const VectorType &                                                 src,
-      const std::function<void(const unsigned int, const unsigned int)> &operation_before_loop,
-      const std::function<void(const unsigned int, const unsigned int)> &operation_after_loop) const
-    {
-      this->data->cell_loop(
-        &LaplaceOperator::local_apply, this, dst, src, operation_before_loop, operation_after_loop);
-    }
-
     /**
      * Transpose matrix-vector multiplication. Since the Laplace matrix is
      * symmetric, it does exactly the same as vmult().

--- a/common_code/solver_cg_optimized.h
+++ b/common_code/solver_cg_optimized.h
@@ -451,26 +451,25 @@ public:
         it++;
 
         dealii::Tensor<1, 7, dealii::VectorizedArray<number>> sums;
-        A.vmult_with_merged_sums(
-          h,
-          d,
-          [&](const unsigned int start_range, const unsigned int end_range) {
-            do_cg_update4b<n_components, number, true>(start_range,
-                                                       end_range,
-                                                       h.begin(),
-                                                       x.begin(),
-                                                       g.begin(),
-                                                       d.begin(),
-                                                       preconditioner,
-                                                       alpha,
-                                                       beta,
-                                                       it % 2 == 1 ? alpha_old : 0,
-                                                       beta_old);
-          },
-          [&](const unsigned int start_range, const unsigned int end_range) {
-            do_cg_update3b<n_components, number>(
-              start_range, end_range, g.begin(), d.begin(), h.begin(), preconditioner, sums);
-          });
+        A.vmult(h,
+                d,
+                [&](const unsigned int start_range, const unsigned int end_range) {
+                  do_cg_update4b<n_components, number, true>(start_range,
+                                                             end_range,
+                                                             h.begin(),
+                                                             x.begin(),
+                                                             g.begin(),
+                                                             d.begin(),
+                                                             preconditioner,
+                                                             alpha,
+                                                             beta,
+                                                             it % 2 == 1 ? alpha_old : 0,
+                                                             beta_old);
+                },
+                [&](const unsigned int start_range, const unsigned int end_range) {
+                  do_cg_update3b<n_components, number>(
+                    start_range, end_range, g.begin(), d.begin(), h.begin(), preconditioner, sums);
+                });
 
         dealii::Tensor<1, 7> results;
         for (unsigned int i = 0; i < 7; ++i)

--- a/common_code/solver_cg_optimized.h
+++ b/common_code/solver_cg_optimized.h
@@ -16,9 +16,10 @@ do_cg_update3b(const unsigned int                                     start,
                const Number *                                         r,
                const Number *                                         d,
                const Number *                                         h,
-               const Number *                                         prec,
+               const DiagonalMatrixBlocked<n_components, Number> &    given_prec,
                dealii::Tensor<1, 7, dealii::VectorizedArray<Number>> &sums)
 {
+  const Number *                         prec = given_prec.get_vector().begin();
   const dealii::VectorizedArray<Number> *arr_r =
     reinterpret_cast<const dealii::VectorizedArray<Number> *>(r);
   const dealii::VectorizedArray<Number> *arr_d =
@@ -62,20 +63,65 @@ do_cg_update3b(const unsigned int                                     start,
 
 
 
+template <int n_components, typename Number>
+void
+do_cg_update3b(const unsigned int start,
+               const unsigned int end,
+               const Number *     r,
+               const Number *     d,
+               const Number *     h,
+               const dealii::PreconditionIdentity &,
+               dealii::Tensor<1, 7, dealii::VectorizedArray<Number>> &sums)
+{
+  const dealii::VectorizedArray<Number> *arr_r =
+    reinterpret_cast<const dealii::VectorizedArray<Number> *>(r);
+  const dealii::VectorizedArray<Number> *arr_d =
+    reinterpret_cast<const dealii::VectorizedArray<Number> *>(d);
+  const dealii::VectorizedArray<Number> *arr_h =
+    reinterpret_cast<const dealii::VectorizedArray<Number> *>(h);
+  dealii::Tensor<1, 7, dealii::VectorizedArray<Number>> local_sum;
+  for (unsigned int i = start / dealii::VectorizedArray<Number>::size();
+       i < end / dealii::VectorizedArray<Number>::size();
+       ++i)
+    {
+      local_sum[0] += arr_d[i] * arr_h[i];
+      local_sum[1] += arr_h[i] * arr_h[i];
+      local_sum[2] += arr_r[i] * arr_h[i];
+      local_sum[3] += arr_r[i] * arr_r[i];
+    }
+  for (unsigned int i =
+         (end / dealii::VectorizedArray<Number>::size()) * dealii::VectorizedArray<Number>::size();
+       i < end;
+       ++i)
+    {
+      local_sum[0][0] += d[i] * h[i];
+      local_sum[1][0] += h[i] * h[i];
+      local_sum[2][0] += r[i] * h[i];
+      local_sum[3][0] += r[i] * r[i];
+    }
+  local_sum[4] = local_sum[2];
+  local_sum[5] = local_sum[1];
+  local_sum[6] = local_sum[3];
+  sums += local_sum;
+}
+
+
+
 template <int n_components, typename Number, bool do_update_h>
 void
-do_cg_update4b(const unsigned int start,
-               const unsigned int end,
-               Number *           h,
-               Number *           x,
-               Number *           r,
-               Number *           p,
-               const Number *     prec,
-               const Number       alpha,
-               const Number       beta,
-               const Number       alpha_old,
-               const Number       beta_old)
+do_cg_update4b(const unsigned int                                 start,
+               const unsigned int                                 end,
+               Number *                                           h,
+               Number *                                           x,
+               Number *                                           r,
+               Number *                                           p,
+               const DiagonalMatrixBlocked<n_components, Number> &given_prec,
+               const Number                                       alpha,
+               const Number                                       beta,
+               const Number                                       alpha_old,
+               const Number                                       beta_old)
 {
+  const Number *                   prec  = given_prec.get_vector().begin();
   dealii::VectorizedArray<Number> *arr_p = reinterpret_cast<dealii::VectorizedArray<Number> *>(p);
   dealii::VectorizedArray<Number> *arr_x = reinterpret_cast<dealii::VectorizedArray<Number> *>(x);
   dealii::VectorizedArray<Number> *arr_r = reinterpret_cast<dealii::VectorizedArray<Number> *>(r);
@@ -162,6 +208,169 @@ do_cg_update4b(const unsigned int start,
 
 
 
+template <int n_components, typename Number, bool do_update_h>
+void
+do_cg_update4b(const unsigned int start,
+               const unsigned int end,
+               Number *           h,
+               Number *           x,
+               Number *           r,
+               Number *           p,
+               const dealii::PreconditionIdentity &,
+               const Number alpha,
+               const Number beta,
+               const Number alpha_old,
+               const Number beta_old)
+{
+  dealii::VectorizedArray<Number> *arr_p = reinterpret_cast<dealii::VectorizedArray<Number> *>(p);
+  dealii::VectorizedArray<Number> *arr_x = reinterpret_cast<dealii::VectorizedArray<Number> *>(x);
+  dealii::VectorizedArray<Number> *arr_r = reinterpret_cast<dealii::VectorizedArray<Number> *>(r);
+  dealii::VectorizedArray<Number> *arr_h = reinterpret_cast<dealii::VectorizedArray<Number> *>(h);
+
+  if (alpha == Number())
+    {
+      for (unsigned int i = start / dealii::VectorizedArray<Number>::size();
+           i < end / dealii::VectorizedArray<Number>::size();
+           ++i)
+        {
+          arr_p[i] = -arr_r[i];
+          if (do_update_h)
+            arr_h[i] = dealii::VectorizedArray<Number>();
+        }
+      for (unsigned int i = (end / dealii::VectorizedArray<Number>::size()) *
+                            dealii::VectorizedArray<Number>::size();
+           i < end;
+           ++i)
+        {
+          p[i] = -r[i];
+          if (do_update_h)
+            h[i] = 0.;
+        }
+    }
+  else if (alpha_old == Number())
+    {
+      for (unsigned int i = start / dealii::VectorizedArray<Number>::size();
+           i < end / dealii::VectorizedArray<Number>::size();
+           ++i)
+        {
+          arr_r[i] += alpha * arr_h[i];
+          arr_p[i] = beta * arr_p[i] - arr_r[i];
+          if (do_update_h)
+            arr_h[i] = dealii::VectorizedArray<Number>();
+        }
+      for (unsigned int i = (end / dealii::VectorizedArray<Number>::size()) *
+                            dealii::VectorizedArray<Number>::size();
+           i < end;
+           ++i)
+        {
+          r[i] += alpha * h[i];
+          p[i] = beta * p[i] - r[i];
+          if (do_update_h)
+            h[i] = 0.;
+        }
+    }
+  else
+    {
+      const Number alpha_plus_alpha_old = alpha + alpha_old / beta_old;
+      const Number alpha_old_beta_old   = alpha_old / beta_old;
+      for (unsigned int i = start / dealii::VectorizedArray<Number>::size();
+           i < end / dealii::VectorizedArray<Number>::size();
+           ++i)
+        {
+          arr_x[i] += alpha_plus_alpha_old * arr_p[i] + alpha_old_beta_old * arr_r[i];
+          arr_r[i] += alpha * arr_h[i];
+          arr_p[i] = beta * arr_p[i] - arr_r[i];
+          if (do_update_h)
+            arr_h[i] = dealii::VectorizedArray<Number>();
+        }
+      for (unsigned int i = (end / dealii::VectorizedArray<Number>::size()) *
+                            dealii::VectorizedArray<Number>::size();
+           i < end;
+           ++i)
+        {
+          x[i] += alpha_plus_alpha_old * p[i] + alpha_old_beta_old * r[i];
+          r[i] += alpha * h[i];
+          p[i] = beta * p[i] - r[i];
+          if (do_update_h)
+            h[i] = 0.;
+        }
+    }
+}
+
+
+
+template <int n_components, typename Number>
+void
+do_cg_update5(const dealii::LinearAlgebra::distributed::Vector<Number> &d,
+              const dealii::LinearAlgebra::distributed::Vector<Number> &g,
+              const DiagonalMatrixBlocked<n_components, Number> &       preconditioner,
+              const Number                                              alpha,
+              const Number                                              alpha_old,
+              const Number                                              beta_old,
+              dealii::LinearAlgebra::distributed::Vector<Number> &      x)
+{
+  const dealii::VectorizedArray<Number> *arr_p =
+    reinterpret_cast<const dealii::VectorizedArray<Number> *>(d.begin());
+  dealii::VectorizedArray<Number> *arr_x =
+    reinterpret_cast<dealii::VectorizedArray<Number> *>(x.begin());
+  const dealii::VectorizedArray<Number> *arr_r =
+    reinterpret_cast<const dealii::VectorizedArray<Number> *>(g.begin());
+  const Number       alpha_plus_alpha_old = alpha + alpha_old / beta_old;
+  const Number       alpha_old_beta_old   = alpha_old / beta_old;
+  const unsigned int end                  = g.local_size();
+  for (unsigned int i = 0; i < end / dealii::VectorizedArray<Number>::size(); ++i)
+    {
+      dealii::VectorizedArray<Number> arr_prec;
+      for (unsigned int v = 0; v < dealii::VectorizedArray<Number>::size(); ++v)
+        arr_prec[v] = preconditioner.get_vector().local_element(
+          (i * dealii::VectorizedArray<Number>::size() + v) / n_components);
+      arr_x[i] += alpha_plus_alpha_old * arr_p[i] + alpha_old_beta_old * arr_prec * arr_r[i];
+    }
+  for (unsigned int i =
+         (end / dealii::VectorizedArray<Number>::size()) * dealii::VectorizedArray<Number>::size();
+       i < end;
+       ++i)
+    x.local_element(i) += alpha_plus_alpha_old * d.local_element(i) +
+                          alpha_old_beta_old *
+                            preconditioner.get_vector().local_element(i / n_components) *
+                            g.local_element(i);
+}
+
+
+
+template <int n_components, typename Number>
+void
+do_cg_update5(const dealii::LinearAlgebra::distributed::Vector<Number> &d,
+              const dealii::LinearAlgebra::distributed::Vector<Number> &g,
+              const dealii::PreconditionIdentity &,
+              const Number                                        alpha,
+              const Number                                        alpha_old,
+              const Number                                        beta_old,
+              dealii::LinearAlgebra::distributed::Vector<Number> &x)
+{
+  const dealii::VectorizedArray<Number> *arr_p =
+    reinterpret_cast<const dealii::VectorizedArray<Number> *>(d.begin());
+  dealii::VectorizedArray<Number> *arr_x =
+    reinterpret_cast<dealii::VectorizedArray<Number> *>(x.begin());
+  const dealii::VectorizedArray<Number> *arr_r =
+    reinterpret_cast<const dealii::VectorizedArray<Number> *>(g.begin());
+  const Number       alpha_plus_alpha_old = alpha + alpha_old / beta_old;
+  const Number       alpha_old_beta_old   = alpha_old / beta_old;
+  const unsigned int end                  = g.local_size();
+  for (unsigned int i = 0; i < end / dealii::VectorizedArray<Number>::size(); ++i)
+    {
+      arr_x[i] += alpha_plus_alpha_old * arr_p[i] + alpha_old_beta_old * arr_r[i];
+    }
+  for (unsigned int i =
+         (end / dealii::VectorizedArray<Number>::size()) * dealii::VectorizedArray<Number>::size();
+       i < end;
+       ++i)
+    x.local_element(i) +=
+      alpha_plus_alpha_old * d.local_element(i) + alpha_old_beta_old * g.local_element(i);
+}
+
+
+
 template <typename VectorType>
 class SolverCGFullMerge : public dealii::SolverBase<VectorType>
 {
@@ -231,17 +440,48 @@ public:
     if (conv != dealii::SolverControl::iterate)
       return;
 
-    number alpha     = 0.;
-    number beta      = 0.;
-    number alpha_old = 0.;
-    number beta_old  = 0.;
+    number                 alpha        = 0.;
+    number                 beta         = 0.;
+    number                 alpha_old    = 0.;
+    number                 beta_old     = 0.;
+    constexpr unsigned int n_components = MatrixType::n_components;
 
     while (conv == dealii::SolverControl::iterate)
       {
         it++;
 
-        const dealii::Tensor<1, 7> results = A.vmult_with_merged_sums(
-          x, g, d, h, preconditioner, alpha, beta, it % 2 == 1 ? alpha_old : 0, beta_old);
+        dealii::Tensor<1, 7, dealii::VectorizedArray<number>> sums;
+        A.vmult_with_merged_sums(
+          h,
+          d,
+          [&](const unsigned int start_range, const unsigned int end_range) {
+            do_cg_update4b<n_components, number, true>(start_range,
+                                                       end_range,
+                                                       h.begin(),
+                                                       x.begin(),
+                                                       g.begin(),
+                                                       d.begin(),
+                                                       preconditioner,
+                                                       alpha,
+                                                       beta,
+                                                       it % 2 == 1 ? alpha_old : 0,
+                                                       beta_old);
+          },
+          [&](const unsigned int start_range, const unsigned int end_range) {
+            do_cg_update3b<n_components, number>(
+              start_range, end_range, g.begin(), d.begin(), h.begin(), preconditioner, sums);
+          });
+
+        dealii::Tensor<1, 7> results;
+        for (unsigned int i = 0; i < 7; ++i)
+          {
+            results[i] = sums[i][0];
+            for (unsigned int v = 1; v < dealii::VectorizedArray<number>::size(); ++v)
+              results[i] += sums[i][v];
+          }
+        dealii::Utilities::MPI::sum(dealii::ArrayView<const double>(results.begin_raw(), 7),
+                                    g.get_partitioner()->get_mpi_communicator(),
+                                    dealii::ArrayView<double>(results.begin_raw(), 7));
 
         alpha_old = alpha;
         beta_old  = beta;
@@ -256,36 +496,8 @@ public:
             if (it % 2 == 1)
               x.add(alpha, d);
             else
-              {
-                constexpr unsigned int           n_components = MatrixType::n_components;
-                dealii::VectorizedArray<number> *arr_p =
-                  reinterpret_cast<dealii::VectorizedArray<number> *>(d.begin());
-                dealii::VectorizedArray<number> *arr_x =
-                  reinterpret_cast<dealii::VectorizedArray<number> *>(x.begin());
-                dealii::VectorizedArray<number> *arr_r =
-                  reinterpret_cast<dealii::VectorizedArray<number> *>(g.begin());
-                const number       alpha_plus_alpha_old = alpha + alpha_old / beta_old;
-                const number       alpha_old_beta_old   = alpha_old / beta_old;
-                const unsigned int end                  = g.local_size();
-                for (unsigned int i = 0; i < end / dealii::VectorizedArray<number>::size(); ++i)
-                  {
-                    dealii::VectorizedArray<number> arr_prec;
-                    for (unsigned int v = 0; v < dealii::VectorizedArray<number>::size(); ++v)
-                      arr_prec[v] = preconditioner.get_vector().local_element(
-                        (i * dealii::VectorizedArray<number>::size() + v) / n_components);
-                    arr_x[i] +=
-                      alpha_plus_alpha_old * arr_p[i] + alpha_old_beta_old * arr_prec * arr_r[i];
-                  }
-                for (unsigned int i = (end / dealii::VectorizedArray<number>::size()) *
-                                      dealii::VectorizedArray<number>::size();
-                     i < end;
-                     ++i)
-                  x.local_element(i) +=
-                    alpha_plus_alpha_old * d.local_element(i) +
-                    alpha_old_beta_old *
-                      preconditioner.get_vector().local_element(i / n_components) *
-                      g.local_element(i);
-              }
+              do_cg_update5<n_components, number>(
+                d, g, preconditioner, alpha, alpha_old, beta_old, x);
             break;
           }
 


### PR DESCRIPTION
Also clean up the CG solver with the merged operations by not leaking the information to the Poisson operator.

It seems that the merged CG solver without preconditioner is not correct, but I do not have the time now to check what goes wrong. @shkodm can you have a look at how the merged CG solver differs from the one in your thesis? I have simply taken the merged version and replaced the preconditioner by simply ones, but as we can see I do a mistake.