### PR TITLE
Enable profiles

### DIFF
--- a/benchmark_basic/bench.cc
+++ b/benchmark_basic/bench.cc
@@ -2,7 +2,7 @@
 #include "../common_code/benchmark.h"
 
 template <typename Operator, typename Preconditioner>
-unsigned int
+std::pair<unsigned int, std::vector<double>>
 run_cg_solver(const Operator &                                  laplace_operator,
               LinearAlgebra::distributed::Vector<double> &      x,
               const LinearAlgebra::distributed::Vector<double> &b,
@@ -14,14 +14,14 @@ run_cg_solver(const Operator &                                  laplace_operator
   try
     {
       solver.solve(laplace_operator, x, b, PreconditionIdentity());
-      return solver_control.last_step();
     }
   catch (SolverControl::NoConvergence &e)
     {
       // prevent the solver to throw an exception in case we should need more
       // than 100 iterations
-      return solver_control.last_step();
     }
+
+  return {solver_control.last_step(), std::vector<double>()};
 }
 
 

--- a/benchmark_merged/bench.cc
+++ b/benchmark_merged/bench.cc
@@ -3,7 +3,7 @@
 #include "../common_code/solver_cg_optimized.h"
 
 template <typename Operator, typename Preconditioner>
-unsigned int
+std::pair<unsigned int, std::vector<double>>
 run_cg_solver(const Operator &                                  laplace_operator,
               LinearAlgebra::distributed::Vector<double> &      x,
               const LinearAlgebra::distributed::Vector<double> &b,
@@ -15,14 +15,14 @@ run_cg_solver(const Operator &                                  laplace_operator
   try
     {
       solver.solve(laplace_operator, x, b, PreconditionIdentity());
-      return solver_control.last_step();
     }
   catch (SolverControl::NoConvergence &e)
     {
       // prevent the solver to throw an exception in case we should need more
       // than 100 iterations
-      return solver_control.last_step();
     }
+
+  return {solver_control.last_step(), std::vector<double>()};
 }
 
 

--- a/benchmark_pipelined/bench.cc
+++ b/benchmark_pipelined/bench.cc
@@ -2,7 +2,7 @@
 #include "../common_code/solver_cg_pipelined.h"
 
 template <typename Operator, typename Preconditioner>
-unsigned int
+std::pair<unsigned int, std::vector<double>>
 run_cg_solver(const Operator &                                  laplace_operator,
               LinearAlgebra::distributed::Vector<double> &      x,
               const LinearAlgebra::distributed::Vector<double> &b,
@@ -14,14 +14,14 @@ run_cg_solver(const Operator &                                  laplace_operator
   try
     {
       solver.solve(laplace_operator, x, b, PreconditionIdentity());
-      return solver_control.last_step();
     }
   catch (SolverControl::NoConvergence &e)
     {
       // prevent the solver to throw an exception in case we should need more
       // than 100 iterations
-      return solver_control.last_step();
     }
+
+  return {solver_control.last_step(), std::vector<double>()};
 }
 
 

--- a/benchmark_pipelined_merged/bench.cc
+++ b/benchmark_pipelined_merged/bench.cc
@@ -2,7 +2,7 @@
 #include "../common_code/solver_cg_pipelined_merged.h"
 
 template <typename Operator, typename Preconditioner>
-unsigned int
+std::pair<unsigned int, std::vector<double>>
 run_cg_solver(const Operator &                                  laplace_operator,
               LinearAlgebra::distributed::Vector<double> &      x,
               const LinearAlgebra::distributed::Vector<double> &b,
@@ -14,14 +14,14 @@ run_cg_solver(const Operator &                                  laplace_operator
   try
     {
       solver.solve(laplace_operator, x, b, PreconditionIdentity());
-      return solver_control.last_step();
     }
   catch (SolverControl::NoConvergence &e)
     {
       // prevent the solver to throw an exception in case we should need more
       // than 100 iterations
-      return solver_control.last_step();
     }
+
+  return {solver_control.last_step(), std::vector<double>()};
 }
 
 

--- a/benchmark_precond/bench.cc
+++ b/benchmark_precond/bench.cc
@@ -2,7 +2,7 @@
 #include "../common_code/benchmark.h"
 
 template <typename Operator, typename Preconditioner>
-unsigned int
+std::pair<unsigned int, std::vector<double>>
 run_cg_solver(const Operator &                                  laplace_operator,
               LinearAlgebra::distributed::Vector<double> &      x,
               const LinearAlgebra::distributed::Vector<double> &b,
@@ -14,14 +14,14 @@ run_cg_solver(const Operator &                                  laplace_operator
   try
     {
       solver.solve(laplace_operator, x, b, preconditioner);
-      return solver_control.last_step();
     }
   catch (SolverControl::NoConvergence &e)
     {
       // prevent the solver to throw an exception in case we should need more
       // than 100 iterations
-      return solver_control.last_step();
     }
+
+  return {solver_control.last_step(), std::vector<double>()};
 }
 
 

--- a/benchmark_precond_merged/bench.cc
+++ b/benchmark_precond_merged/bench.cc
@@ -3,7 +3,7 @@
 #include "../common_code/solver_cg_optimized.h"
 
 template <typename Operator, typename Preconditioner>
-unsigned int
+std::pair<unsigned int, std::vector<double>>
 run_cg_solver(const Operator &                                  laplace_operator,
               LinearAlgebra::distributed::Vector<double> &      x,
               const LinearAlgebra::distributed::Vector<double> &b,
@@ -15,14 +15,14 @@ run_cg_solver(const Operator &                                  laplace_operator
   try
     {
       solver.solve(laplace_operator, x, b, preconditioner);
-      return solver_control.last_step();
     }
   catch (SolverControl::NoConvergence &e)
     {
       // prevent the solver to throw an exception in case we should need more
       // than 100 iterations
-      return solver_control.last_step();
     }
+
+  return {solver_control.last_step(), std::vector<double>()};
 }
 
 

--- a/benchmark_s_step/bench.cc
+++ b/benchmark_s_step/bench.cc
@@ -7,7 +7,7 @@
 unsigned int n_steps = 1;
 
 template <typename Operator, typename Preconditioner>
-unsigned int
+std::pair<unsigned int, std::vector<double>>
 run_cg_solver(const Operator &                                  laplace_operator,
               LinearAlgebra::distributed::Vector<double> &      x,
               const LinearAlgebra::distributed::Vector<double> &b,
@@ -21,14 +21,14 @@ run_cg_solver(const Operator &                                  laplace_operator
   try
     {
       solver.solve(laplace_operator, x, b);
-      return solver_control.last_step();
     }
   catch (SolverControl::NoConvergence &e)
     {
       // prevent the solver to throw an exception in case we should need more
       // than 100 iterations
-      return solver_control.last_step();
     }
+
+  return {solver_control.last_step(), solver.get_profile()};
 }
 
 

--- a/common_code/timer.h
+++ b/common_code/timer.h
@@ -1,0 +1,25 @@
+#ifndef timer_h_
+#define timer_h_
+
+class ScopedTimer
+{
+public:
+  ScopedTimer(double &result)
+    : result(result)
+    , temp(std::chrono::system_clock::now())
+  {}
+
+  ~ScopedTimer()
+  {
+    result +=
+      std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - temp)
+        .count() /
+      1e6;
+  }
+
+private:
+  double &                                           result;
+  std::chrono::time_point<std::chrono::system_clock> temp;
+};
+
+#endif


### PR DESCRIPTION
The return value of the benchmarks has been extended with a vector (of timings of regions):
https://github.com/kronbichler/mf_data_locality/blob/fca815cee851c23e85849c4e0016a5f8200f6170/common_code/benchmark.h#L41-L46

The timings are appended at the end of the table:

https://github.com/kronbichler/mf_data_locality/blob/fca815cee851c23e85849c4e0016a5f8200f6170/common_code/benchmark.h#L244-L258

I have only implemented this approach for s-step CG; for the other CG variants it could be done similarly. We might need to make a copy of `SolverCG` from deal.II.

What do you thinkt?