### PR TITLE
Use Utilities::MPI::min_max_avg

### DIFF
--- a/common_code/benchmark.h
+++ b/common_code/benchmark.h
@@ -255,6 +255,10 @@ run_templated(const unsigned int s, const bool short_output, const MPI_Comm &com
         std::cout << "Error mat-vec:         " << error << std::endl;
     }
 
+#if true
+  const auto profile_min_max_avg = Utilities::MPI::min_max_avg(profile, MPI_COMM_WORLD);
+#endif
+
   if (Utilities::MPI::this_mpi_process(MPI_COMM_WORLD) == 0 && short_output == true)
     {
       std::cout << std::setprecision(4)                                                      //
@@ -266,8 +270,13 @@ run_templated(const unsigned int s, const bool short_output, const MPI_Comm &com
                 << " " << std::setw(4) << n_iterations                                       //
                 << " " << std::setw(9) << matvec_time;                                       //
 
+#if true
+      for (const auto &t : profile_min_max_avg)
+        std::cout << " " << std::setw(9) << t.avg / std::max(1u, n_iterations);
+#else
       for (const auto &t : profile)
-        std::cout << " " << std::setw(9) << t / n_iterations;
+        std::cout << " " << std::setw(9) << t / std::max(1u, n_iterations);
+#endif
 
       std::cout << std::endl;
     }

--- a/common_code/timer.h
+++ b/common_code/timer.h
@@ -12,9 +12,9 @@ public:
   ~ScopedTimer()
   {
     result +=
-      std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - temp)
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now() - temp)
         .count() /
-      1e6;
+      1e9;
   }
 
 private:


### PR DESCRIPTION
References https://github.com/kronbichler/mf_data_locality/pull/20#discussion_r549357827.

rank 0:
```
 p  q      cells        dofs  timeCGit throughput itCG    timeMV
 1  3          6          72       inf          0    0 1.024e-05         0  1.19e-07 1.925e-06         0
 1  3          8          81 3.055e-05  2.651e+06    1 6.202e-06 7.382e-06  3.27e-07 1.054e-05   7.6e-08
 1  3         12         108 3.303e-05   3.27e+06    2 1.476e-05 1.586e-05 2.665e-07 9.285e-06   6.7e-08
 1  3         16         135 2.922e-05   4.62e+06    2  8.74e-06 1.117e-05 2.675e-07 9.871e-06     7e-08
 1  3         24         189 2.219e-05  8.518e+06    5 9.591e-06 1.053e-05 2.064e-07 8.211e-06  6.86e-08
 1  3         32         225 2.282e-05  9.859e+06    8 1.097e-05 1.173e-05   1.7e-07 8.363e-06   4.1e-08
 1  3         48         315 2.287e-05  1.377e+07    9 1.186e-05   1.2e-05 2.009e-07 8.182e-06 4.389e-08
 1  3         64         375 2.614e-05  1.435e+07   11 1.446e-05  1.54e-05  1.59e-07  9.04e-06   3.4e-08
 1  3         96         525   2.8e-05  1.875e+07   12 1.537e-05 1.709e-05 1.529e-07 8.986e-06 3.217e-08
 1  3        128         675 2.705e-05  2.495e+07   13 1.571e-05 1.694e-05 4.788e-07 7.682e-06 2.025e-07
 1  3        192         975 2.941e-05  3.315e+07   15 1.659e-05 1.874e-05 4.723e-07 8.219e-06 2.069e-07
 1  3        256        1215 3.009e-05  4.037e+07   17 1.889e-05 2.042e-05 4.265e-07 7.481e-06 1.944e-07
 1  3        384        1755 3.658e-05  4.797e+07   19 2.485e-05 2.576e-05 4.614e-07 8.661e-06 1.708e-07
 1  3        512        2187 3.858e-05  5.669e+07   21 2.753e-05 2.772e-05  5.31e-07  8.75e-06 1.773e-07
 1  3        768        3159 4.561e-05  6.927e+07   25 3.467e-05 3.486e-05  4.93e-07 8.864e-06 1.763e-07
 1  3       1024        4131 4.812e-05  8.585e+07   28 3.688e-05 3.676e-05 5.729e-07 9.348e-06 1.917e-07
 1  3       1536        6075 5.148e-05   1.18e+08   31 4.035e-05 4.051e-05 7.954e-07 8.662e-06 2.217e-07
 1  3       2048        7803 6.006e-05  1.299e+08   35 4.926e-05 4.892e-05 7.142e-07 9.076e-06 2.504e-07
 1  3       3072       11475 7.322e-05  1.567e+08   38 5.875e-05 5.995e-05 9.909e-07 1.068e-05 3.712e-07
 1  3       4096       14739 8.082e-05  1.824e+08   43 6.653e-05 6.881e-05 9.017e-07 9.708e-06 3.601e-07
 1  3       6144       21675 0.0001062   2.04e+08   51 9.357e-05  9.38e-05 1.349e-06 9.703e-06 4.511e-07
 1  3       8192       28611  0.000127  2.252e+08   56 0.0001131  0.000114 1.709e-06 9.856e-06 5.599e-07
 1  3      12288       42483 0.0001783  2.383e+08   65  0.000161 0.0001639 2.183e-06 1.047e-05 8.511e-07
 1  3      16384       55539 0.0002209  2.514e+08   72 0.0002037 0.0002047 2.729e-06 1.157e-05 9.151e-07
 1  3      24576       82467 0.0003082  2.675e+08   79 0.0002909 0.0002906 4.219e-06 1.121e-05 1.254e-06
 1  3      32768      107811 0.0004192  2.572e+08   87 0.0003749 0.0003981  5.25e-06 1.326e-05 1.531e-06
 1  3      49152      160083 0.0005971  2.681e+08  100 0.0005624 0.0005692 8.073e-06 1.597e-05 2.456e-06
 1  3      65536      212355 0.0007953   2.67e+08  100 0.0007594 0.0007615 1.102e-05  1.83e-05 2.967e-06
 1  3      98304      316899   0.00119  2.664e+08  100  0.001141  0.001141 1.842e-05 2.384e-05 4.533e-06
 1  3     131072      418275  0.001636  2.557e+08  100  0.001562  0.001572 2.752e-05 2.764e-05 5.703e-06
 1  3     196608      624195  0.002478  2.519e+08  100  0.002351  0.002384 4.656e-05  3.66e-05 8.062e-06
 1  3     262144      823875  0.003319  2.483e+08  100  0.003131  0.003193 6.616e-05 4.602e-05 1.068e-05
 1  3     393216     1229475  0.005042  2.439e+08  100  0.004823  0.004829 0.0001204 7.126e-05 1.707e-05
 1  3     524288     1635075   0.00678  2.412e+08  100  0.006424  0.006437  0.000203 0.0001125 2.314e-05
 1  3     786432     2446275   0.01036  2.361e+08  100  0.009715  0.009677  0.000393 0.0001917 9.554e-05
```

 
avg:
```
 p  q      cells        dofs  timeCGit throughput itCG    timeMV
 1  3          6          72       inf          0    0 1.058e-05         0 1.219e-07 2.199e-06         0
 1  3          8          81 3.293e-05   2.46e+06    1 5.845e-06 7.164e-06 3.628e-07  1.11e-05  6.03e-08
 1  3         12         108 3.562e-05  3.032e+06    2 1.453e-05 1.668e-05 3.281e-07 9.826e-06 8.135e-08
 1  3         16         135 3.181e-05  4.243e+06    2 8.482e-06 1.115e-05 2.786e-07 1.223e-05 6.546e-08
 1  3         24         189 2.156e-05  8.767e+06    5 9.347e-06  1.02e-05  2.02e-07  8.17e-06 4.524e-08
 1  3         32         225 2.194e-05  1.026e+07    8 1.073e-05 1.104e-05 1.992e-07 8.025e-06 4.943e-08
 1  3         48         315 2.221e-05  1.418e+07    9 1.122e-05 1.166e-05 2.024e-07 7.823e-06 5.354e-08
 1  3         64         375 2.526e-05  1.485e+07   11 1.433e-05 1.523e-05 1.859e-07 8.148e-06 4.975e-08
 1  3         96         525 2.876e-05  1.826e+07   12 1.553e-05 1.698e-05  2.02e-07 9.809e-06 6.722e-08
 1  3        128         675 2.714e-05  2.487e+07   13 1.619e-05 1.691e-05 2.147e-07  8.37e-06 6.962e-08
 1  3        192         975  2.95e-05  3.305e+07   15 1.653e-05  1.83e-05 2.524e-07 9.246e-06 9.842e-08
 1  3        256        1215 3.009e-05  4.038e+07   17 1.933e-05 1.932e-05 2.707e-07 8.956e-06 1.002e-07
 1  3        384        1755  3.74e-05  4.693e+07   19 2.426e-05 2.629e-05 3.278e-07 9.092e-06 1.306e-07
 1  3        512        2187 3.925e-05  5.572e+07   21 2.729e-05 2.839e-05 3.521e-07 8.811e-06 1.503e-07
 1  3        768        3159 4.605e-05   6.86e+07   25 3.452e-05  3.51e-05 3.603e-07 9.019e-06 2.159e-07
 1  3       1024        4131 4.843e-05   8.53e+07   28 3.671e-05 3.708e-05 3.905e-07 9.361e-06 3.288e-07
 1  3       1536        6075 5.138e-05  1.182e+08   31 4.023e-05 4.031e-05 4.119e-07 9.199e-06  3.16e-07
 1  3       2048        7803 5.901e-05  1.322e+08   35 4.772e-05 4.762e-05 4.566e-07  9.42e-06 3.832e-07
 1  3       3072       11475 7.261e-05   1.58e+08   38 6.045e-05 5.974e-05 6.237e-07 1.055e-05 6.093e-07
 1  3       4096       14739 7.985e-05  1.846e+08   43 6.655e-05 6.775e-05 6.954e-07 9.769e-06 6.157e-07
 1  3       6144       21675 0.0001057  2.051e+08   51 9.354e-05 9.296e-05 9.127e-07 1.016e-05 6.152e-07
 1  3       8192       28611  0.000128  2.235e+08   56 0.0001127 0.0001152 1.029e-06 9.854e-06 8.408e-07
 1  3      12288       42483 0.0001784  2.381e+08   65 0.0001627 0.0001641 1.598e-06 1.073e-05 1.085e-06
 1  3      16384       55539 0.0002192  2.533e+08   72 0.0002042 0.0002023 2.244e-06 1.208e-05 1.634e-06
 1  3      24576       82467 0.0003108  2.653e+08   79 0.0003157 0.0002925 3.053e-06 1.188e-05 2.251e-06
 1  3      32768      107811 0.0004074  2.647e+08   87 0.0003841 0.0003858 4.508e-06   1.3e-05 2.903e-06
 1  3      49152      160083 0.0006053  2.645e+08  100 0.0005985 0.0005772 6.766e-06  1.59e-05  4.14e-06
 1  3      65536      212355 0.0007942  2.674e+08  100 0.0007908 0.0007593 9.891e-06 1.853e-05 4.892e-06
 1  3      98304      316899  0.001215  2.608e+08  100  0.001146  0.001166 1.605e-05 2.373e-05 7.018e-06
 1  3     131072      418275  0.001643  2.546e+08  100  0.001571  0.001578 2.358e-05 2.999e-05 8.906e-06
 1  3     196608      624195  0.002493  2.504e+08  100  0.002383  0.002397 4.039e-05 4.045e-05 1.223e-05
 1  3     262144      823875  0.003368  2.447e+08  100  0.003196  0.003237 5.846e-05 5.279e-05 1.584e-05
 1  3     393216     1229475  0.005078  2.421e+08  100   0.00486   0.00486 0.0001098 8.306e-05 2.169e-05
 1  3     524288     1635075  0.006786  2.409e+08  100  0.006409  0.006434 0.0001878 0.0001312 2.896e-05
 1  3     786432     2446275   0.01039  2.353e+08  100  0.009672   0.00971 0.0003598 0.0002354 8.358e-05
```

... and some minor adjustments