### PR TITLE
Add script for parsing likwid data

### DIFF
--- a/common_code/benchmark.h
+++ b/common_code/benchmark.h
@@ -195,7 +195,9 @@ run_templated(const unsigned int s, const bool short_output, const MPI_Comm &com
   unsigned int        n_iterations = numbers::invalid_unsigned_int;
   std::vector<double> profile;
 #ifdef LIKWID_PERFMON
-  LIKWID_MARKER_START("cg_solver");
+
+  std::string region_name = "cg_solver_" + std::to_string(dof_handler.n_dofs());
+  LIKWID_MARKER_START(region_name.c_str());
 #endif
   for (unsigned int t = 0; t < 4; ++t)
     {
@@ -212,11 +214,12 @@ run_templated(const unsigned int s, const bool short_output, const MPI_Comm &com
         }
     }
 #ifdef LIKWID_PERFMON
-  LIKWID_MARKER_STOP("cg_solver");
+  LIKWID_MARKER_STOP(region_name.c_str());
 #endif
 
 #ifdef LIKWID_PERFMON
-  LIKWID_MARKER_START("matvec");
+  region_name = "matvec_" + std::to_string(dof_handler.n_dofs());
+  LIKWID_MARKER_START(region_name.c_str());
 #endif
   double matvec_time = 1e10;
   for (unsigned int t = 0; t < 2; ++t)
@@ -228,7 +231,7 @@ run_templated(const unsigned int s, const bool short_output, const MPI_Comm &com
       matvec_time = std::min(data.max / 50, matvec_time);
     }
 #ifdef LIKWID_PERFMON
-  LIKWID_MARKER_STOP("matvec");
+  LIKWID_MARKER_STOP(region_name.c_str());
 #endif
 
   if (short_output == false)

--- a/scripts/likwid_parser.py
+++ b/scripts/likwid_parser.py
@@ -1,0 +1,119 @@
+import re
+import pandas as pd
+import itertools
+
+
+class LikwidParser:
+
+    # NOTE: Achitecture dependent and probably should be adjusted depending on it
+    groups = {
+        "Metric": {
+            "L3CACHE": ["L3 request rate", "L3 miss rate", "L3 miss ratio"],
+            "MEM": [
+                "Memory data volume",
+                "Memory read bandwidth",
+                "Memory write bandwidth",
+                "Memory bandwidth",
+            ],
+            "CACHES": [
+                "L3 to/from system bandwidth",
+                "L3 to/from system data volume",
+                "System to L3 bandwidth",
+                "System to L3 data volume",
+                "L3 to system bandwidth",
+                "L3 to system data volume",
+                "L1 to/from L2 bandwidth",
+                "L1 to/from L2 data volume",
+                "L3 to L2 load bandwidth",
+                "L3 to L2 load data volume",
+                "L2 to L3 evict bandwidth",
+                "L2 to L3 evict data volume",
+                "L2 to/from L3 bandwidth",
+                "L2 to/from L3 data volume",
+                "Memory write data volume",
+                "Memory read data volume",
+            ],
+        }
+    }
+
+    def __init__(self, filename):
+
+        f = open(filename)
+        content = f.read()
+        likwid_sections = re.findall("Region ((.*?)_(\d+)),", content)
+        sections = list({_[1] for _ in likwid_sections})
+        sizes = list({int(_[2]) for _ in likwid_sections})
+        sizes.sort()
+
+        self.filename = filename
+        self.sections = sections
+        self.sizes = sizes
+        self.flat_groups = list(
+            itertools.chain(*(v for k, v in LikwidParser.groups.get("Metric").items()))
+        )
+        self.likwid_data = {
+            s: {
+                "STAT": pd.DataFrame(columns=self.flat_groups, index=self.sizes),
+                "SUM": pd.DataFrame(columns=self.flat_groups, index=self.sizes),
+            }
+            for s in sections
+        }
+        self.parse()
+
+    def get_number_from_csv(self, extract_type, numbers):
+
+        # need to summarize across different sockets
+        if extract_type == "SUM":
+            number = sum(0 if x == "nil" else float(x) for x in numbers)
+        else:
+            tmp = re.compile(r"(.*?),")
+            matches = tmp.findall("Metric,Sum,Min,Max,Avg,")
+            matched_index = matches.index("Avg")
+            index_to_extract = matched_index
+            number = float(numbers[index_to_extract])
+        return number
+
+    def parse(self):
+
+        with open(self.filename, "r") as f:
+            all_lines = f.readlines()
+            for i, line in enumerate(all_lines):
+                # try to get current group
+                likwid_group_reg = re.search(r"Metric.*?,(\w+)", line)
+                if likwid_group_reg is not None:
+                    likwid_group = likwid_group_reg.group(1)
+                    if likwid_group in LikwidParser.groups["Metric"]:
+                        # find find the size of current region
+                        match = re.search("Region ((.*?)_(\d+)),", line)
+                        if match:
+                            section = match.group(2)
+                            size = int(match.group(3))
+                            # finally find all the metrics we might need here
+                            # and try to get it
+                            needed_metrics = LikwidParser.groups["Metric"].get(
+                                likwid_group
+                            )
+
+                            while True and i < len(all_lines) - 1:
+                                i = i + 1
+                                line = all_lines[i]
+                                regcsv = re.compile(r"(.*?),")
+                                items = regcsv.findall(line)
+                                if len(items) < 1:
+                                    break
+                                first, *rest = [i for i in items if i]
+                                partial_match = next(
+                                    (_ for _ in needed_metrics if _ in first), None
+                                )
+                                if first == "TABLE":
+                                    break
+                                if first == "Metric" or not partial_match:
+                                    continue
+
+                                is_stat = "STAT" in line
+                                extract_type = "STAT" if is_stat else "SUM"
+
+                                number = self.get_number_from_csv(extract_type,rest)
+                                self.likwid_data[section][extract_type].at[
+                                    size, partial_match
+                                ] = number


### PR DESCRIPTION
Usage: 

```python
# output of e.g  likwid-mpirun  -n 40  -g CACHES -m -O build/benchmark_pipelined/bench > likwid_pipelined_merged.log
filename = '/home/shkdm/Prog/Paper/mf_data_locality/likwid/likwid_pipelined_merged.log'
parser = LikwidParser(filename)
# get metric from the maticular section ('cg_solver') or ('matvec'), more can be easily added
# use SUM for summing up quantities across cores (e.g. memory transfer) that is only measured on sockets, 
# AVG otherwise
data = parser.likwid_data['cg_solver']['SUM']
sizes = data.index.to_numpy()
# iteration count is extracted from the standard (non likwid output of benchmark)
iteration_count = parser.benchmark_data['itCG'].to_numpy()
# size of double
element_size = 8
# number of runs of benchmark 
run_number = 4
plt.plot(sizes, data['Memory read data volume']* 1e9  / sizes/ (iteration_count * element_size * run_number) , color = 'red')
```

First results look reasonable, but will analyze other methods and maybe adjust before merging. "Memory read data volume" and "Memory write data volume" seems to be interesting results for large problem sizes. 