### PR TITLE
Allow preconditioner on all components as well

### DIFF
--- a/common_code/diagonal_matrix_blocked.h
+++ b/common_code/diagonal_matrix_blocked.h
@@ -17,12 +17,19 @@ public:
                 dealii::ExcNotImplemented("Dimension mismatch " + std::to_string(dst.size()) +
                                           " vs " + std::to_string(dim) + " x " +
                                           std::to_string(diagonal.size())));
-    for (unsigned int i = 0, c = 0; i < diagonal.local_size(); ++i)
+    if (dim == 1)
       {
-        const Number diag = diagonal.local_element(i);
-        for (unsigned int d = 0; d < dim; ++d, ++c)
-          dst.local_element(c) = diag * src.local_element(c);
+        DEAL_II_OPENMP_SIMD_PRAGMA
+        for (unsigned int i = 0; i < diagonal.local_size(); ++i)
+          dst.local_element(i) = diagonal.local_element(i) * src.local_element(i);
       }
+    else
+      for (unsigned int i = 0, c = 0; i < diagonal.local_size(); ++i)
+        {
+          const Number diag = diagonal.local_element(i);
+          for (unsigned int d = 0; d < dim; ++d, ++c)
+            dst.local_element(c) = diag * src.local_element(c);
+        }
   }
 
   const dealii::LinearAlgebra::distributed::Vector<Number> &


### PR DESCRIPTION
For a cross-comparison, I would like to enable the preconditioner which duplicates all entries. Now, we can select `n_components_prec` to either `1` (meaning that it duplicates the entries) or `n_components` (default, meaning that we only use a single value).